### PR TITLE
HTMLのフォーム要素にrequired属性を追加

### DIFF
--- a/views/edit.erb
+++ b/views/edit.erb
@@ -3,7 +3,7 @@
 <form action="/articles/<%= @article['id'] %>" method="post">
     <input type="hidden" name="_method" value="patch">
     <div>
-        <input type="text" id="title" name="title" value="<%= h @article['title'] %>">
+        <input type="text" id="title" name="title" value="<%= h @article['title'] %>" required>
     </div>
     <div>
         <textarea id="body" name="body"><%= h @article['body'] %></textarea>

--- a/views/new.erb
+++ b/views/new.erb
@@ -2,7 +2,7 @@
 
 <form action="/articles" method="post">
     <div>
-        <input type="text" id="title" name="title">
+        <input type="text" id="title" name="title" required>
     </div>
     <div>
         <textarea id="body" name="body"></textarea>


### PR DESCRIPTION
タイトルが空のまま送信されないように、クライアント側の簡易的なバリデーションとして `required` 属性を追加。

### 変更点
- `new.erb` と `edit.erb` のタイトル入力フィールドに `required` 属性を追加。

### 背景
- 前回の課題提出時の指摘より。
  - https://github.com/note103/sinatra-practice/pull/1#discussion_r1855562320
- タイトル未登録時に「何も起きない」のではユーザーにわかりづらいため、バリデーションエラーが発生するように対応。